### PR TITLE
simplify background tasks orchestration

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -1,8 +1,8 @@
 use crate::configuration::JobConfig;
 use crate::domain::UserId;
 use crate::feed::{find_favicon, FeedId, ParsedFeed};
-use crate::fetch_bytes;
 use crate::shutdown::Shutdown;
+use crate::{fetch_bytes, RunResult};
 use blake2::{Blake2b512, Digest};
 use feed_rs::model::Entry as RawFeedEntry;
 use serde::{Deserialize, Serialize};
@@ -114,7 +114,7 @@ impl JobRunner {
         })
     }
 
-    pub async fn run(mut self, mut shutdown: Shutdown) -> anyhow::Result<()> {
+    pub async fn run(mut self, mut shutdown: Shutdown) -> RunResult {
         let mut interval = tokio::time::interval(self.config.run_interval());
 
         'outer_loop: loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ pub mod tem;
 #[cfg(test)]
 pub mod tests;
 
+/// The [`Result`] type used by the top-level `run` functions (like [`crate::job::JobRunner`]).
+pub type RunResult = Result<(), anyhow::Error>;
+
 pub fn error_chain_fmt(err: &impl std::error::Error, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     writeln!(f, "{}\n", err)?;
     let mut current = err.source();

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,6 +1,7 @@
 use crate::configuration::{ApplicationConfig, DatabaseConfig, SessionConfig, TEMConfig};
 use crate::sessions::{CleanupConfig as SessionStoreCleanupConfig, PgSessionStore};
 use crate::shutdown::Shutdown;
+use crate::RunResult;
 use crate::{routes::*, tem};
 use actix_session::SessionMiddleware;
 use actix_web::{cookie, dev::Server};
@@ -79,7 +80,7 @@ impl Application {
         Ok(Application { port, server })
     }
 
-    pub async fn run(self, mut shutdown: Shutdown) -> Result<(), Error> {
+    pub async fn run(self, mut shutdown: Shutdown) -> RunResult {
         tokio::select! {
             _ = shutdown.recv() => {
                     info!("application shutting down");


### PR DESCRIPTION
use a [JoinSet](https://docs.rs/tokio/latest/tokio/task/struct.JoinSet.html) to wait on multiple futures instead of using my ad hoc solution.